### PR TITLE
Removed binding to native input in EmailInput.svelte

### DIFF
--- a/src/lib/EmailInput.svelte
+++ b/src/lib/EmailInput.svelte
@@ -61,7 +61,7 @@
         placeholder={placeholder}
         type="email"
         name={name}
-        bind:value={value}
+        value={value}
       />
   {/snippet}
   </BaseInput>


### PR DESCRIPTION
I noticed that when you tried to clear an email field that after a half second or so the value just magically reappears.

This snippet should recreate the issue.
```
<script>
  let email = $state("");
  
  function clear() {
    email = "";
  }
<script/>


<EmailInput
    placeholder="Add an email"
    bind:value={emailToAdd}
  />
<Button onClick={clear}>Add</Button>
```