### PR TITLE
Fixed wiring of onchange prop in CashInput and CheckBox

### DIFF
--- a/src/lib/CashInput.svelte
+++ b/src/lib/CashInput.svelte
@@ -99,6 +99,7 @@
       displayValue = '-';
       value = null;
       updateBoundsErrors(null);
+      onChange();
       return;
     }
 
@@ -107,12 +108,16 @@
     displayValue = formatNumber(numericValue);
     value = numericValue;
     updateBoundsErrors(numericValue);
+    onChange();
   };
 
   const handleBlur = () => {
     isTypingMinus = false;
     const clamped = clamp(value);
-    if (clamped !== value) value = clamped;
+    if (clamped !== value) {
+      value = clamped;
+      onChange();
+    }
     displayValue = formatNumber(value);
     fieldState.removeError('min');
     fieldState.removeError('max');

--- a/src/lib/CheckBox.svelte
+++ b/src/lib/CheckBox.svelte
@@ -41,6 +41,7 @@
             id={name}
             {required}
             bind:checked={value}
+            onchange={() => onChange()}
             {disabled}
         />
     </div>


### PR DESCRIPTION
The onchange prop were not working for Cashinput and checkbox
BaseInput only wires onChange to its built-in <input> element. CashInput and CheckBox supply a custom input snippet, so their onChange props never fire. 